### PR TITLE
fix: Prevent overlapping flush from occurring causing exception when releasing semaphore

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,4 +43,12 @@
   <ItemGroup Label="Package Includes">
     <None Include="$(MSBuildThisFileDirectory)build\assets\nugetlogo.png" Pack="true" PackagePath="\" />
   </ItemGroup>
+  
+  <!--
+  We need this to stop build from producing .deps.json files that contains "ReferencedProject.Reference". 
+  It will cause exceptions in CluedIn Server, saying that the item has already been added (ReferencedProject.dll)
+  -->
+  <PropertyGroup Label="FixBuildDefault">
+    <IncludeProjectsNotInAssetsFileInDepsFile>false</IncludeProjectsNotInAssetsFileInDepsFile>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Description
Work Item ID: [AB#41489](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/41489)


## How has it been tested? 
Local environment