### PR TITLE
feat: Disallow spaces in configuration field

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup Label="Dependency Versions">
     <_EntityFramework>6.0.16</_EntityFramework>
-    <_ComponentHost>3.1.0</_ComponentHost>
+    <_ComponentHost>3.2.0</_ComponentHost>
     <_AutoFixture>4.11.0</_AutoFixture>
-    <_CluedIn>4.0.0</_CluedIn>
+    <_CluedIn>4.5.0-alpha.*</_CluedIn>
   </PropertyGroup>
   <ItemGroup>
     <!--

--- a/docs/4.5.0-release-notes.md
+++ b/docs/4.5.0-release-notes.md
@@ -1,3 +1,3 @@
 # Features
-- Updated to support CluedIn 4.4.0
+- Updated to support CluedIn 4.5.0
 - Spaces in export target configuration fields will trigger an error message.

--- a/docs/4.5.0-release-notes.md
+++ b/docs/4.5.0-release-notes.md
@@ -1,0 +1,3 @@
+# Features
+- Updated to support CluedIn 4.4.0
+- Spaces in export target configuration fields will trigger an error message.

--- a/src/Connector.SqlServer/AzureEventHubConstants.cs
+++ b/src/Connector.SqlServer/AzureEventHubConstants.cs
@@ -37,21 +37,35 @@ namespace CluedIn.Connector.AzureEventHub
 
         public static AuthMethods AuthMethods = new AuthMethods
         {
-            token = new Control[]
+            Token = new Control[]
             {
                 new Control
                 {
-                    name = KeyName.ConnectionString,
-                    displayName = "Connection String",
-                    type = "input",
-                    isRequired = true
+                    Name = KeyName.ConnectionString,
+                    DisplayName = "Connection String",
+                    Type = "input",
+                    IsRequired = true,
+                    ValidationRules = new List<Dictionary<string, string>>()
+                    {
+                        new() {
+                            { "regex", "\\s" },
+                            { "message", "Spaces are not allowed" }
+                        }
+                    },
                 },
                 new Control
                 {
-                    name = KeyName.Name,
-                    displayName = "Name",
-                    type = "input",
-                    isRequired = true
+                    Name = KeyName.Name,
+                    DisplayName = "Name",
+                    Type = "input",
+                    IsRequired = true,
+                    ValidationRules = new List<Dictionary<string, string>>()
+                    {
+                        new() {
+                            { "regex", "\\s" },
+                            { "message", "Spaces are not allowed" }
+                        }
+                    },
                 }
             }
         };


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#43441](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/43441)

Fields in the export target configuration will now be validated to check for spaces.
![image](https://github.com/user-attachments/assets/ab2c974b-c9d6-4719-b6d9-faad3f7470c3)

## How has it been tested? <!-- Remove if not needed -->
Manually in local
