### PR TITLE
fix: Verify connection string before creating event hub export target

### DIFF
--- a/docs/4.5.0-release-notes.md
+++ b/docs/4.5.0-release-notes.md
@@ -5,3 +5,4 @@
 
 # Fixes
 - Rename display value for "Name" to "Event Hub Name"
+- Verify connection string before creating Event Hub export target


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#46723](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/46723)

Display invalid connection string if validation failed
![image](https://github.com/user-attachments/assets/3346583f-20bc-4580-be4c-93ca1bd219b4)

## How has it been tested? <!-- Remove if not needed -->
Manually in local


