### PR TITLE
feat: add opt-in message combining to reduce per-message Event Hub cost

### DIFF
--- a/docs/4.5.2-release-notes.md
+++ b/docs/4.5.2-release-notes.md
@@ -1,3 +1,4 @@
 # Features
+- Add opt-in setting to combine multiple records into a single Event Hub message (with configurable batch size), for customers billed per message by their downstream consumer
 
 # Fix

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "6.0.400",
-    "rollForward": "latestFeature",
+    "rollForward": "latestMajor",
     "allowPrerelease": "false"
   },
   "msbuild-sdks": {

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "6.0.400",
-    "rollForward": "latestMajor",
+    "version": "8.0.100",
+    "rollForward": "latestFeature",
     "allowPrerelease": "false"
   },
   "msbuild-sdks": {

--- a/src/Connector.SqlServer/AssemblyInfo.cs
+++ b/src/Connector.SqlServer/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("CluedIn.Connector.AzureEventHub.Unit.Tests")]

--- a/src/Connector.SqlServer/AzureEventHubConnectorJobData.cs
+++ b/src/Connector.SqlServer/AzureEventHubConnectorJobData.cs
@@ -15,15 +15,66 @@ namespace CluedIn.Connector.AzureEventHub
 
             ConnectionString = GetValue<string>(configuration, AzureEventHubConstants.KeyName.ConnectionString);
             Name = GetValue<string>(configuration, AzureEventHubConstants.KeyName.Name);
+            CombineMessages = GetBool(configuration, AzureEventHubConstants.KeyName.CombineMessages, false);
+
+            // Clamped to DefaultFlushSize: batching can only make combined messages smaller than a full buffer
+            // flush, never larger - see the comment on the buffer's construction in AzureEventHubConnector.
+            BatchSize = Math.Clamp(
+                GetPositiveInt(configuration, AzureEventHubConstants.KeyName.BatchSize, AzureEventHubConstants.DefaultBatchSize),
+                AzureEventHubConstants.MinBatchSize,
+                AzureEventHubConstants.DefaultFlushSize);
         }
 
         public string ConnectionString { get; set; }
 
         public string Name { get; set; }
 
+        public bool CombineMessages { get; set; }
+
+        public int BatchSize { get; set; }
+
+        private static bool GetBool(IDictionary<string, object> configuration, string key, bool defaultValue)
+        {
+            if (configuration.TryGetValue(key, out var raw) && raw != null)
+            {
+                if (raw is bool b)
+                {
+                    return b;
+                }
+
+                if (bool.TryParse(raw.ToString(), out var parsed))
+                {
+                    return parsed;
+                }
+            }
+
+            return defaultValue;
+        }
+
+        private static int GetPositiveInt(IDictionary<string, object> configuration, string key, int defaultValue)
+        {
+            if (configuration.TryGetValue(key, out var raw) && raw != null)
+            {
+                if (raw is int i && i > 0)
+                {
+                    return i;
+                }
+
+                if (int.TryParse(raw.ToString(), out var parsed) && parsed > 0)
+                {
+                    return parsed;
+                }
+            }
+
+            return defaultValue;
+        }
+
         protected bool Equals(AzureEventHubConnectorJobData other)
         {
-            return ConnectionString == other.ConnectionString && Name == other.Name;
+            return ConnectionString == other.ConnectionString
+                && Name == other.Name
+                && CombineMessages == other.CombineMessages
+                && BatchSize == other.BatchSize;
         }
 
         public override bool Equals(object obj)
@@ -48,14 +99,16 @@ namespace CluedIn.Connector.AzureEventHub
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(ConnectionString, Name);
+            return HashCode.Combine(ConnectionString, Name, CombineMessages, BatchSize);
         }
 
         public IDictionary<string, object> ToDictionary()
         {
             return new Dictionary<string, object> {
                 { AzureEventHubConstants.KeyName.ConnectionString, ConnectionString },
-                { AzureEventHubConstants.KeyName.Name, Name }
+                { AzureEventHubConstants.KeyName.Name, Name },
+                { AzureEventHubConstants.KeyName.CombineMessages, CombineMessages },
+                { AzureEventHubConstants.KeyName.BatchSize, BatchSize }
             };
         }
     }

--- a/src/Connector.SqlServer/AzureEventHubConnectorJobData.cs
+++ b/src/Connector.SqlServer/AzureEventHubConnectorJobData.cs
@@ -34,40 +34,42 @@ namespace CluedIn.Connector.AzureEventHub
 
         public int BatchSize { get; set; }
 
+        // Deliberately not the base class's GetValue<T>: that helper throws on a value it can't convert (e.g. an
+        // empty or non-numeric string), whereas these two need to fall back to defaultValue on anything they
+        // can't parse - the exact format the UI posts these two fields in wasn't confirmed when they were added.
+        private static bool TryGetRawConfigValue(IDictionary<string, object> configuration, string key, out object raw)
+        {
+            return configuration.TryGetValue(key, out raw) && raw != null;
+        }
+
         private static bool GetBool(IDictionary<string, object> configuration, string key, bool defaultValue)
         {
-            if (configuration.TryGetValue(key, out var raw) && raw != null)
+            if (!TryGetRawConfigValue(configuration, key, out var raw))
             {
-                if (raw is bool b)
-                {
-                    return b;
-                }
-
-                if (bool.TryParse(raw.ToString(), out var parsed))
-                {
-                    return parsed;
-                }
+                return defaultValue;
             }
 
-            return defaultValue;
+            if (raw is bool b)
+            {
+                return b;
+            }
+
+            return bool.TryParse(raw.ToString(), out var parsed) ? parsed : defaultValue;
         }
 
         private static int GetPositiveInt(IDictionary<string, object> configuration, string key, int defaultValue)
         {
-            if (configuration.TryGetValue(key, out var raw) && raw != null)
+            if (!TryGetRawConfigValue(configuration, key, out var raw))
             {
-                if (raw is int i && i > 0)
-                {
-                    return i;
-                }
-
-                if (int.TryParse(raw.ToString(), out var parsed) && parsed > 0)
-                {
-                    return parsed;
-                }
+                return defaultValue;
             }
 
-            return defaultValue;
+            if (raw is int i && i > 0)
+            {
+                return i;
+            }
+
+            return int.TryParse(raw.ToString(), out var parsed) && parsed > 0 ? parsed : defaultValue;
         }
 
         protected bool Equals(AzureEventHubConnectorJobData other)

--- a/src/Connector.SqlServer/AzureEventHubConnectorJobData.cs
+++ b/src/Connector.SqlServer/AzureEventHubConnectorJobData.cs
@@ -17,8 +17,9 @@ namespace CluedIn.Connector.AzureEventHub
             Name = GetValue<string>(configuration, AzureEventHubConstants.KeyName.Name);
             CombineMessages = GetBool(configuration, AzureEventHubConstants.KeyName.CombineMessages, false);
 
-            // Clamped to DefaultFlushSize: batching can only make combined messages smaller than a full buffer
-            // flush, never larger - see the comment on the buffer's construction in AzureEventHubConnector.
+            // Clamped to DefaultFlushSize, the buffer's ceiling (a single flush can never exceed it, though it
+            // may be less - see AzureEventHubConnector's constructor comment and Buffer.AutoAdjustMaxSize), so
+            // batching can only make combined messages smaller than the buffer would otherwise send, never larger.
             BatchSize = Math.Clamp(
                 GetPositiveInt(configuration, AzureEventHubConstants.KeyName.BatchSize, AzureEventHubConstants.DefaultBatchSize),
                 AzureEventHubConstants.MinBatchSize,

--- a/src/Connector.SqlServer/AzureEventHubConstants.cs
+++ b/src/Connector.SqlServer/AzureEventHubConstants.cs
@@ -11,7 +11,18 @@ namespace CluedIn.Connector.AzureEventHub
         {
             public const string ConnectionString = "connectinString";
             public const string Name = "name";
+            public const string CombineMessages = "combineMessages";
+            public const string BatchSize = "batchSize";
         }
+
+        // Some Event Hub tiers cap message size at 1 MB; this leaves headroom for the JSON wrapper/encoding overhead.
+        public const int MaxCombinedMessageBytes = 800_000;
+        public const int DefaultBatchSize = 20;
+        public const int MinBatchSize = 1;
+        // Fixed buffer flush size/cadence - tied to the platform's default RabbitMQ prefetch count, see the
+        // comment in AzureEventHubConnector's constructor. BatchSize is clamped to this as an upper bound.
+        public const int DefaultFlushSize = 50;
+        public const int FlushTimeoutMilliseconds = 10000;
 
         public const string ConnectorName = "AzureEventConnector";
         public const string ConnectorComponentName = "AzureEventConnector";
@@ -72,7 +83,27 @@ namespace CluedIn.Connector.AzureEventHub
 
         public static IEnumerable<Control> Properties = new List<Control>
         {
-
+            new Control
+            {
+                Name = KeyName.CombineMessages,
+                DisplayName = "Combine multiple records into a single Event Hub message (true/false, default false)",
+                Type = "input",
+                IsRequired = false,
+            },
+            new Control
+            {
+                Name = KeyName.BatchSize,
+                DisplayName = $"Batch size - records per combined message, 1-{DefaultFlushSize} (default {DefaultBatchSize})",
+                Type = "input",
+                IsRequired = false,
+                ValidationRules = new List<Dictionary<string, string>>()
+                {
+                    new() {
+                        { "regex", "^[0-9]*$" },
+                        { "message", "Must be a whole number" }
+                    }
+                },
+            },
         };
 
         public static readonly ComponentEmailDetails ComponentEmailDetails = new ComponentEmailDetails {

--- a/src/Connector.SqlServer/AzureEventHubConstants.cs
+++ b/src/Connector.SqlServer/AzureEventHubConstants.cs
@@ -86,7 +86,7 @@ namespace CluedIn.Connector.AzureEventHub
             new Control
             {
                 Name = KeyName.CombineMessages,
-                DisplayName = "Combine multiple records into a single Event Hub message (true/false, default false)",
+                DisplayName = "Combine multiple records into a single Event Hub message",
                 Type = "checkbox",
                 IsRequired = false,
             },

--- a/src/Connector.SqlServer/AzureEventHubConstants.cs
+++ b/src/Connector.SqlServer/AzureEventHubConstants.cs
@@ -99,8 +99,8 @@ namespace CluedIn.Connector.AzureEventHub
                 ValidationRules = new List<Dictionary<string, string>>()
                 {
                     new() {
-                        { "regex", "^[0-9]*$" },
-                        { "message", "Must be a whole number" }
+                        { "regex", "^[1-9][0-9]*$" },
+                        { "message", "Must be a whole number greater than zero" }
                     }
                 },
             },

--- a/src/Connector.SqlServer/AzureEventHubConstants.cs
+++ b/src/Connector.SqlServer/AzureEventHubConstants.cs
@@ -87,7 +87,7 @@ namespace CluedIn.Connector.AzureEventHub
             {
                 Name = KeyName.CombineMessages,
                 DisplayName = "Combine multiple records into a single Event Hub message (true/false, default false)",
-                Type = "input",
+                Type = "checkbox",
                 IsRequired = false,
             },
             new Control

--- a/src/Connector.SqlServer/AzureEventHubConstants.cs
+++ b/src/Connector.SqlServer/AzureEventHubConstants.cs
@@ -87,6 +87,7 @@ namespace CluedIn.Connector.AzureEventHub
             {
                 Name = KeyName.CombineMessages,
                 DisplayName = "Combine multiple records into a single Event Hub message",
+                Help = "When enabled, records are combined into a single message wrapped as {\"count\", \"messages\"} instead of being sent individually - make sure your downstream consumer can parse this format.",
                 Type = "checkbox",
                 IsRequired = false,
             },

--- a/src/Connector.SqlServer/AzureEventHubConstants.cs
+++ b/src/Connector.SqlServer/AzureEventHubConstants.cs
@@ -94,7 +94,8 @@ namespace CluedIn.Connector.AzureEventHub
             new Control
             {
                 Name = KeyName.BatchSize,
-                DisplayName = $"Batch size - records per combined message, 1-{DefaultFlushSize} (default {DefaultBatchSize})",
+                DisplayName = "Batch size",
+                Help = $"Records per combined message, 1-{DefaultFlushSize} (default {DefaultBatchSize}). Only applies when combining messages is enabled.",
                 Type = "input",
                 IsRequired = false,
                 ValidationRules = new List<Dictionary<string, string>>()

--- a/src/Connector.SqlServer/Connector/AzureEventHubConnector.cs
+++ b/src/Connector.SqlServer/Connector/AzureEventHubConnector.cs
@@ -31,7 +31,16 @@ namespace CluedIn.Connector.AzureEventHub.Connector
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _clockService = clockService;
 
-            _buffer = new PartitionedBuffer<AzureEventHubConnectorJobData, EventData>(50, 10000, Flush);
+            // Buffer<T>.Add blocks the caller (a RabbitMQ message handler) until its item is flushed, so the
+            // number of concurrently in-flight adds is capped by RabbitMQ's prefetch count (default 50) - not by
+            // this buffer. This size must stay fixed at/below that prefetch count: if it could grow past it, the
+            // buffer could never fill by count (no 51st concurrent caller could ever arrive) and every flush would
+            // fall back to the 10s idle timeout, collapsing throughput. BatchSize (see Flush) only subdivides
+            // what this buffer already collected, so it can be configured independently without this risk.
+            _buffer = new PartitionedBuffer<AzureEventHubConnectorJobData, EventData>(
+                AzureEventHubConstants.DefaultFlushSize,
+                AzureEventHubConstants.FlushTimeoutMilliseconds,
+                Flush);
 
             _logger.LogInformation("[AzureEventHub] AzureEventHubConnector Initialized");
         }
@@ -60,15 +69,71 @@ namespace CluedIn.Connector.AzureEventHub.Connector
                 _cache.Add(configuration, client = new EventHubProducerClient(configuration.ConnectionString, configuration.Name));
             }
 
+            var toSend = configuration.CombineMessages
+                ? Chunk(eventData, configuration.BatchSize).Select(CombineEventData).ToArray()
+                : eventData;
+
             try
             {
-                await client.SendAsync(eventData);
+                await client.SendAsync(toSend);
             }
             catch
             {
                 _cache.Remove(configuration);
                 throw;
             }
+        }
+
+        // Subdivides one flush's worth of records (at most AzureEventHubConstants.DefaultFlushSize, per the
+        // buffer's fixed size) into groups of at most batchSize, further split if a group's combined byte size
+        // would exceed the Event Hub's max message size. batchSize is clamped <= DefaultFlushSize by JobData,
+        // so it can only ever make combined messages smaller than a full flush, never larger.
+        private static IEnumerable<EventData[]> Chunk(EventData[] items, int batchSize)
+        {
+            var chunk = new List<EventData>(Math.Min(batchSize, items.Length));
+            var chunkBytes = 0;
+
+            foreach (var item in items)
+            {
+                var itemBytes = item.Body.ToArray().Length;
+
+                if (chunk.Count > 0 && (chunk.Count >= batchSize || chunkBytes + itemBytes > AzureEventHubConstants.MaxCombinedMessageBytes))
+                {
+                    yield return chunk.ToArray();
+                    chunk = new List<EventData>(Math.Min(batchSize, items.Length));
+                    chunkBytes = 0;
+                }
+
+                chunk.Add(item);
+                chunkBytes += itemBytes;
+            }
+
+            if (chunk.Count > 0)
+            {
+                yield return chunk.ToArray();
+            }
+        }
+
+        // Combines the raw JSON bodies of multiple already-serialized EventData items into a single
+        // message body, wrapped as { "count": N, "messages": [ ... ] }, without re-parsing each body.
+        private static EventData CombineEventData(EventData[] items)
+        {
+            var sb = new StringBuilder();
+            sb.Append("{\"count\":").Append(items.Length).Append(",\"messages\":[");
+
+            for (var i = 0; i < items.Length; i++)
+            {
+                if (i > 0)
+                {
+                    sb.Append(',');
+                }
+
+                sb.Append(Encoding.UTF8.GetString(items[i].Body.ToArray()));
+            }
+
+            sb.Append("]}");
+
+            return new EventData(Encoding.UTF8.GetBytes(sb.ToString()));
         }
 
         public override async Task CreateContainer(ExecutionContext executionContext, Guid connectorProviderDefinitionId, IReadOnlyCreateContainerModelV2 model)

--- a/src/Connector.SqlServer/Connector/AzureEventHubConnector.cs
+++ b/src/Connector.SqlServer/Connector/AzureEventHubConnector.cs
@@ -33,7 +33,10 @@ namespace CluedIn.Connector.AzureEventHub.Connector
 
             // Buffer<T>.Add blocks the caller (a RabbitMQ message handler) until its item is flushed, so the
             // number of concurrently in-flight adds is capped by RabbitMQ's prefetch count (default 50) - not by
-            // this buffer. This size must stay fixed at/below that prefetch count: if it could grow past it, the
+            // this buffer. This value is the buffer's *ceiling*: it sizes Buffer<T>'s internal semaphores/arrays
+            // once at construction and never grows past it, though Buffer<T>.AutoAdjustMaxSize can shrink the
+            // effective per-flush trigger below it (and back up) at runtime under sustained low throughput - see
+            // that method. The ceiling itself must stay at/below the prefetch count: if it could exceed it, the
             // buffer could never fill by count (no 51st concurrent caller could ever arrive) and every flush would
             // fall back to the 10s idle timeout, collapsing throughput. BatchSize (see Flush) only subdivides
             // what this buffer already collected, so it can be configured independently without this risk.
@@ -84,10 +87,12 @@ namespace CluedIn.Connector.AzureEventHub.Connector
             }
         }
 
-        // Subdivides one flush's worth of records (at most AzureEventHubConstants.DefaultFlushSize, per the
-        // buffer's fixed size) into groups of at most batchSize, further split if a group's combined byte size
-        // would exceed the Event Hub's max message size. batchSize is clamped <= DefaultFlushSize by JobData,
-        // so it can only ever make combined messages smaller than a full flush, never larger.
+        // Subdivides one flush's worth of records - at most AzureEventHubConstants.DefaultFlushSize, though it
+        // may be fewer if Buffer<T>.AutoAdjustMaxSize has shrunk the flush trigger under low throughput - into
+        // groups of at most batchSize, further split if a group's combined byte size would exceed the Event
+        // Hub's max message size. batchSize is clamped <= DefaultFlushSize by JobData, so it can only ever make
+        // combined messages smaller than a full flush would allow, never larger; fewer items than batchSize
+        // just yields one smaller group, which is a no-op for correctness.
         private static IEnumerable<EventData[]> Chunk(EventData[] items, int batchSize)
         {
             var chunk = new List<EventData>(Math.Min(batchSize, items.Length));

--- a/src/Connector.SqlServer/Connector/AzureEventHubConnector.cs
+++ b/src/Connector.SqlServer/Connector/AzureEventHubConnector.cs
@@ -53,7 +53,14 @@ namespace CluedIn.Connector.AzureEventHub.Connector
             _buffer.Dispose();
         }
 
-        private readonly Dictionary<AzureEventHubConnectorJobData, EventHubProducerClient> _cache = new Dictionary<AzureEventHubConnectorJobData, EventHubProducerClient>();
+        // Keyed by (ConnectionString, Name) rather than the full AzureEventHubConnectorJobData: those two fields
+        // are all that determine which physical Event Hub connection/producer client is needed. JobData's
+        // Equals/GetHashCode also include CombineMessages/BatchSize (it doubles as the buffer partition key,
+        // where that inclusion is required so setting changes get picked up). Keying this cache on the full
+        // JobData instead would mean routinely tuning BatchSize/CombineMessages leaks a producer client - and
+        // its underlying AMQP connection - on every change, since nothing here ever evicts or disposes a
+        // superseded cache entry.
+        private readonly Dictionary<(string ConnectionString, string Name), EventHubProducerClient> _cache = new();
 
         private async Task Flush(AzureEventHubConnectorJobData configuration, EventData[] eventData)
         {
@@ -67,9 +74,11 @@ namespace CluedIn.Connector.AzureEventHub.Connector
                 return;
             }
 
-            if (!_cache.TryGetValue(configuration, out var client))
+            var clientKey = (configuration.ConnectionString, configuration.Name);
+
+            if (!_cache.TryGetValue(clientKey, out var client))
             {
-                _cache.Add(configuration, client = new EventHubProducerClient(configuration.ConnectionString, configuration.Name));
+                _cache.Add(clientKey, client = new EventHubProducerClient(configuration.ConnectionString, configuration.Name));
             }
 
             try
@@ -92,7 +101,7 @@ namespace CluedIn.Connector.AzureEventHub.Connector
             }
             catch
             {
-                _cache.Remove(configuration);
+                _cache.Remove(clientKey);
                 throw;
             }
         }

--- a/src/Connector.SqlServer/Connector/AzureEventHubConnector.cs
+++ b/src/Connector.SqlServer/Connector/AzureEventHubConnector.cs
@@ -119,7 +119,7 @@ namespace CluedIn.Connector.AzureEventHub.Connector
 
             foreach (var item in items)
             {
-                var itemBytes = item.Body.ToArray().Length;
+                var itemBytes = item.Body.Length;
 
                 if (chunk.Count > 0 && (chunk.Count >= batchSize || chunkBytes + itemBytes > AzureEventHubConstants.MaxCombinedMessageBytes))
                 {
@@ -152,7 +152,7 @@ namespace CluedIn.Connector.AzureEventHub.Connector
                     sb.Append(',');
                 }
 
-                sb.Append(Encoding.UTF8.GetString(items[i].Body.ToArray()));
+                sb.Append(Encoding.UTF8.GetString(items[i].Body.Span));
             }
 
             sb.Append("]}");

--- a/src/Connector.SqlServer/Connector/AzureEventHubConnector.cs
+++ b/src/Connector.SqlServer/Connector/AzureEventHubConnector.cs
@@ -72,13 +72,23 @@ namespace CluedIn.Connector.AzureEventHub.Connector
                 _cache.Add(configuration, client = new EventHubProducerClient(configuration.ConnectionString, configuration.Name));
             }
 
-            var toSend = configuration.CombineMessages
-                ? Chunk(eventData, configuration.BatchSize).Select(CombineEventData).ToArray()
-                : eventData;
-
             try
             {
-                await client.SendAsync(toSend);
+                if (configuration.CombineMessages)
+                {
+                    // Each chunk must be its own Event Hub batch. Collecting every chunk into one array and
+                    // handing it to a single SendAsync call would pack multiple already-near-the-cap combined
+                    // messages into one physical batch, which can exceed Event Hub's real per-batch size limit
+                    // even though every individual chunk stayed under MaxCombinedMessageBytes.
+                    foreach (var chunk in Chunk(eventData, configuration.BatchSize))
+                    {
+                        await client.SendAsync(new[] { CombineEventData(chunk) });
+                    }
+                }
+                else
+                {
+                    await client.SendAsync(eventData);
+                }
             }
             catch
             {

--- a/src/Connector.SqlServer/Connector/AzureEventHubConnector.cs
+++ b/src/Connector.SqlServer/Connector/AzureEventHubConnector.cs
@@ -93,7 +93,7 @@ namespace CluedIn.Connector.AzureEventHub.Connector
         // Hub's max message size. batchSize is clamped <= DefaultFlushSize by JobData, so it can only ever make
         // combined messages smaller than a full flush would allow, never larger; fewer items than batchSize
         // just yields one smaller group, which is a no-op for correctness.
-        private static IEnumerable<EventData[]> Chunk(EventData[] items, int batchSize)
+        internal static IEnumerable<EventData[]> Chunk(EventData[] items, int batchSize)
         {
             var chunk = new List<EventData>(Math.Min(batchSize, items.Length));
             var chunkBytes = 0;
@@ -121,7 +121,7 @@ namespace CluedIn.Connector.AzureEventHub.Connector
 
         // Combines the raw JSON bodies of multiple already-serialized EventData items into a single
         // message body, wrapped as { "count": N, "messages": [ ... ] }, without re-parsing each body.
-        private static EventData CombineEventData(EventData[] items)
+        internal static EventData CombineEventData(EventData[] items)
         {
             var sb = new StringBuilder();
             sb.Append("{\"count\":").Append(items.Length).Append(",\"messages\":[");

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -8,10 +8,9 @@
          scoped to test projects only via this file rather than the shipped connector assembly under src/. -->
     <LangVersion>11</LangVersion>
     <!-- CI's UseDotNet@2 step installs only the single SDK/runtime pinned in ../global.json (now 8.0.100, bumped
-         for the LangVersion 11 requirement above) - it does not also install the net6.0 runtime these test
-         projects target, so the compiled net6.0 test binaries can't otherwise be *run* by dotnet test/vstest
-         (confirmed via a CI failure: "Framework: 'Microsoft.NETCore.App', version '6.0.0' ... found: 8.0.30").
-         This lets the test host roll forward to the installed .NET 8 runtime at execution time instead. -->
+         for the LangVersion 11 requirement above), not the net6.0 runtime these test projects target - without
+         this, the compiled net6.0 test binaries can't be run by dotnet test/vstest. Lets the test host roll
+         forward to the installed .NET 8 runtime at execution time instead. -->
     <RollForward>LatestMajor</RollForward>
   </PropertyGroup>
 

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -7,6 +7,12 @@
          literals ("""..."""). Compile-time only - doesn't affect the net6.0 target or runtime behavior, and is
          scoped to test projects only via this file rather than the shipped connector assembly under src/. -->
     <LangVersion>11</LangVersion>
+    <!-- CI's UseDotNet@2 step installs only the single SDK/runtime pinned in ../global.json (now 8.0.100, bumped
+         for the LangVersion 11 requirement above) - it does not also install the net6.0 runtime these test
+         projects target, so the compiled net6.0 test binaries can't otherwise be *run* by dotnet test/vstest
+         (confirmed via a CI failure: "Framework: 'Microsoft.NETCore.App', version '6.0.0' ... found: 8.0.30").
+         This lets the test host roll forward to the installed .NET 8 runtime at execution time instead. -->
+    <RollForward>LatestMajor</RollForward>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -3,6 +3,10 @@
 
   <PropertyGroup>
     <IsTestProject>true</IsTestProject>
+    <!-- Raised from the repo-wide default (C# 10, implied by net6.0) so test assertions can use raw string
+         literals ("""..."""). Compile-time only - doesn't affect the net6.0 target or runtime behavior, and is
+         scoped to test projects only via this file rather than the shipped connector assembly under src/. -->
+    <LangVersion>11</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/integration/Connector.AzureEventHub.Integration.Tests/AzureEventHubConnectorTests.cs
+++ b/test/integration/Connector.AzureEventHub.Integration.Tests/AzureEventHubConnectorTests.cs
@@ -19,6 +19,8 @@ using CluedIn.Core.Data.Vocabularies;
 using CluedIn.Core.Streams.Models;
 using FluentAssertions;
 using Moq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Abstractions;
 using ExecutionContext = CluedIn.Core.ExecutionContext;
@@ -337,48 +339,56 @@ namespace CluedIn.Connector.AzureEventHub.Integration.Tests
 
             var receivedBody = Encoding.UTF8.GetString(eventData.Body.ToArray());
 
-            // Asserted as one raw literal (rather than parsing the JSON and checking pieces of it) so the whole
-            // wire message is visible here and any future change to it shows up as an obvious diff in this test.
-            // This is 3 hardcoded record blocks because batchSize is fixed at 3 above - if batchSize changes,
-            // this literal needs a matching number of blocks added/removed by hand.
-            // $$""" ... """ - a raw string literal (no quote-escaping) using $$ so interpolation needs {{expr}},
-            // leaving the JSON's own single { and } braces literal with no escaping needed either.
-            receivedBody.Should().Be($$"""
-{"count":{{batchSize}},"messages":[{
-  "user.lastName": "Picard",
-  "Name": "Jean Luc Picard",
-  "Id": "{{entityIds[0]}}",
-  "PersistHash": "1lzghdhhgqlnucj078/77q==",
-  "OriginEntityCode": "/Person#Acceptance:{{entityIds[0]}}",
-  "EntityType": "/Person",
-  "Codes": [
-    "/Person#Acceptance:{{entityIds[0]}}"
-  ],
-  "ChangeType": "Changed"
-},{
-  "user.lastName": "Picard",
-  "Name": "Jean Luc Picard",
-  "Id": "{{entityIds[1]}}",
-  "PersistHash": "1lzghdhhgqlnucj078/77q==",
-  "OriginEntityCode": "/Person#Acceptance:{{entityIds[1]}}",
-  "EntityType": "/Person",
-  "Codes": [
-    "/Person#Acceptance:{{entityIds[1]}}"
-  ],
-  "ChangeType": "Changed"
-},{
-  "user.lastName": "Picard",
-  "Name": "Jean Luc Picard",
-  "Id": "{{entityIds[2]}}",
-  "PersistHash": "1lzghdhhgqlnucj078/77q==",
-  "OriginEntityCode": "/Person#Acceptance:{{entityIds[2]}}",
-  "EntityType": "/Person",
-  "Codes": [
-    "/Person#Acceptance:{{entityIds[2]}}"
-  ],
-  "ChangeType": "Changed"
-}]}
-""");
+            // Reformatted through JToken before comparing, rather than asserting the raw wire bytes: gives the
+            // literal below consistent, readable indentation, and makes the assertion tolerant of inconsequential
+            // whitespace differences (e.g. a Json.NET version/setting change) while still failing on any real
+            // structural or content change.
+            var formattedBody = JToken.Parse(receivedBody).ToString(Formatting.Indented);
+
+            formattedBody.Should().Be(
+                $$"""
+                  {
+                    "count": {{batchSize}},
+                    "messages": [
+                      {
+                        "user.lastName": "Picard",
+                        "Name": "Jean Luc Picard",
+                        "Id": "{{entityIds[0]}}",
+                        "PersistHash": "1lzghdhhgqlnucj078/77q==",
+                        "OriginEntityCode": "/Person#Acceptance:{{entityIds[0]}}",
+                        "EntityType": "/Person",
+                        "Codes": [
+                          "/Person#Acceptance:{{entityIds[0]}}"
+                        ],
+                        "ChangeType": "Changed"
+                      },
+                      {
+                        "user.lastName": "Picard",
+                        "Name": "Jean Luc Picard",
+                        "Id": "{{entityIds[1]}}",
+                        "PersistHash": "1lzghdhhgqlnucj078/77q==",
+                        "OriginEntityCode": "/Person#Acceptance:{{entityIds[1]}}",
+                        "EntityType": "/Person",
+                        "Codes": [
+                          "/Person#Acceptance:{{entityIds[1]}}"
+                        ],
+                        "ChangeType": "Changed"
+                      },
+                      {
+                        "user.lastName": "Picard",
+                        "Name": "Jean Luc Picard",
+                        "Id": "{{entityIds[2]}}",
+                        "PersistHash": "1lzghdhhgqlnucj078/77q==",
+                        "OriginEntityCode": "/Person#Acceptance:{{entityIds[2]}}",
+                        "EntityType": "/Person",
+                        "Codes": [
+                          "/Person#Acceptance:{{entityIds[2]}}"
+                        ],
+                        "ChangeType": "Changed"
+                      }
+                    ]
+                  }
+                  """);
         }
     }
 }

--- a/test/integration/Connector.AzureEventHub.Integration.Tests/AzureEventHubConnectorTests.cs
+++ b/test/integration/Connector.AzureEventHub.Integration.Tests/AzureEventHubConnectorTests.cs
@@ -341,40 +341,44 @@ namespace CluedIn.Connector.AzureEventHub.Integration.Tests
             // wire message is visible here and any future change to it shows up as an obvious diff in this test.
             // This is 3 hardcoded record blocks because batchSize is fixed at 3 above - if batchSize changes,
             // this literal needs a matching number of blocks added/removed by hand.
-            receivedBody.Should().Be($@"{{""count"":{batchSize},""messages"":[{{
-  ""user.lastName"": ""Picard"",
-  ""Name"": ""Jean Luc Picard"",
-  ""Id"": ""{entityIds[0]}"",
-  ""PersistHash"": ""1lzghdhhgqlnucj078/77q=="",
-  ""OriginEntityCode"": ""/Person#Acceptance:{entityIds[0]}"",
-  ""EntityType"": ""/Person"",
-  ""Codes"": [
-    ""/Person#Acceptance:{entityIds[0]}""
+            // $$""" ... """ - a raw string literal (no quote-escaping) using $$ so interpolation needs {{expr}},
+            // leaving the JSON's own single { and } braces literal with no escaping needed either.
+            receivedBody.Should().Be($$"""
+{"count":{{batchSize}},"messages":[{
+  "user.lastName": "Picard",
+  "Name": "Jean Luc Picard",
+  "Id": "{{entityIds[0]}}",
+  "PersistHash": "1lzghdhhgqlnucj078/77q==",
+  "OriginEntityCode": "/Person#Acceptance:{{entityIds[0]}}",
+  "EntityType": "/Person",
+  "Codes": [
+    "/Person#Acceptance:{{entityIds[0]}}"
   ],
-  ""ChangeType"": ""Changed""
-}},{{
-  ""user.lastName"": ""Picard"",
-  ""Name"": ""Jean Luc Picard"",
-  ""Id"": ""{entityIds[1]}"",
-  ""PersistHash"": ""1lzghdhhgqlnucj078/77q=="",
-  ""OriginEntityCode"": ""/Person#Acceptance:{entityIds[1]}"",
-  ""EntityType"": ""/Person"",
-  ""Codes"": [
-    ""/Person#Acceptance:{entityIds[1]}""
+  "ChangeType": "Changed"
+},{
+  "user.lastName": "Picard",
+  "Name": "Jean Luc Picard",
+  "Id": "{{entityIds[1]}}",
+  "PersistHash": "1lzghdhhgqlnucj078/77q==",
+  "OriginEntityCode": "/Person#Acceptance:{{entityIds[1]}}",
+  "EntityType": "/Person",
+  "Codes": [
+    "/Person#Acceptance:{{entityIds[1]}}"
   ],
-  ""ChangeType"": ""Changed""
-}},{{
-  ""user.lastName"": ""Picard"",
-  ""Name"": ""Jean Luc Picard"",
-  ""Id"": ""{entityIds[2]}"",
-  ""PersistHash"": ""1lzghdhhgqlnucj078/77q=="",
-  ""OriginEntityCode"": ""/Person#Acceptance:{entityIds[2]}"",
-  ""EntityType"": ""/Person"",
-  ""Codes"": [
-    ""/Person#Acceptance:{entityIds[2]}""
+  "ChangeType": "Changed"
+},{
+  "user.lastName": "Picard",
+  "Name": "Jean Luc Picard",
+  "Id": "{{entityIds[2]}}",
+  "PersistHash": "1lzghdhhgqlnucj078/77q==",
+  "OriginEntityCode": "/Person#Acceptance:{{entityIds[2]}}",
+  "EntityType": "/Person",
+  "Codes": [
+    "/Person#Acceptance:{{entityIds[2]}}"
   ],
-  ""ChangeType"": ""Changed""
-}}]}}");
+  "ChangeType": "Changed"
+}]}
+""");
         }
     }
 }

--- a/test/integration/Connector.AzureEventHub.Integration.Tests/AzureEventHubConnectorTests.cs
+++ b/test/integration/Connector.AzureEventHub.Integration.Tests/AzureEventHubConnectorTests.cs
@@ -19,7 +19,6 @@ using CluedIn.Core.Data.Vocabularies;
 using CluedIn.Core.Streams.Models;
 using FluentAssertions;
 using Moq;
-using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Abstractions;
 using ExecutionContext = CluedIn.Core.ExecutionContext;
@@ -337,15 +336,45 @@ namespace CluedIn.Connector.AzureEventHub.Integration.Tests
             }
 
             var receivedBody = Encoding.UTF8.GetString(eventData.Body.ToArray());
-            var parsed = JObject.Parse(receivedBody);
 
-            ((int)parsed["count"]).Should().Be(batchSize);
-
-            var messages = (JArray)parsed["messages"];
-            messages.Should().HaveCount(batchSize);
-
-            var receivedIds = messages.Select(m => (string)m["Id"]).ToArray();
-            receivedIds.Should().BeEquivalentTo(entityIds);
+            // Asserted as one raw literal (rather than parsing the JSON and checking pieces of it) so the whole
+            // wire message is visible here and any future change to it shows up as an obvious diff in this test.
+            // This is 3 hardcoded record blocks because batchSize is fixed at 3 above - if batchSize changes,
+            // this literal needs a matching number of blocks added/removed by hand.
+            receivedBody.Should().Be($@"{{""count"":{batchSize},""messages"":[{{
+  ""user.lastName"": ""Picard"",
+  ""Name"": ""Jean Luc Picard"",
+  ""Id"": ""{entityIds[0]}"",
+  ""PersistHash"": ""1lzghdhhgqlnucj078/77q=="",
+  ""OriginEntityCode"": ""/Person#Acceptance:{entityIds[0]}"",
+  ""EntityType"": ""/Person"",
+  ""Codes"": [
+    ""/Person#Acceptance:{entityIds[0]}""
+  ],
+  ""ChangeType"": ""Changed""
+}},{{
+  ""user.lastName"": ""Picard"",
+  ""Name"": ""Jean Luc Picard"",
+  ""Id"": ""{entityIds[1]}"",
+  ""PersistHash"": ""1lzghdhhgqlnucj078/77q=="",
+  ""OriginEntityCode"": ""/Person#Acceptance:{entityIds[1]}"",
+  ""EntityType"": ""/Person"",
+  ""Codes"": [
+    ""/Person#Acceptance:{entityIds[1]}""
+  ],
+  ""ChangeType"": ""Changed""
+}},{{
+  ""user.lastName"": ""Picard"",
+  ""Name"": ""Jean Luc Picard"",
+  ""Id"": ""{entityIds[2]}"",
+  ""PersistHash"": ""1lzghdhhgqlnucj078/77q=="",
+  ""OriginEntityCode"": ""/Person#Acceptance:{entityIds[2]}"",
+  ""EntityType"": ""/Person"",
+  ""Codes"": [
+    ""/Person#Acceptance:{entityIds[2]}""
+  ],
+  ""ChangeType"": ""Changed""
+}}]}}");
         }
     }
 }

--- a/test/integration/Connector.AzureEventHub.Integration.Tests/AzureEventHubConnectorTests.cs
+++ b/test/integration/Connector.AzureEventHub.Integration.Tests/AzureEventHubConnectorTests.cs
@@ -19,6 +19,7 @@ using CluedIn.Core.Data.Vocabularies;
 using CluedIn.Core.Streams.Models;
 using FluentAssertions;
 using Moq;
+using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Abstractions;
 using ExecutionContext = CluedIn.Core.ExecutionContext;
@@ -213,6 +214,138 @@ namespace CluedIn.Connector.AzureEventHub.Integration.Tests
   }}
 }}");
             }
+        }
+
+        [Fact]
+        public async Task VerifyCanStoreData_WithCombineMessagesEnabled_CombinesRecordsIntoSingleMessage()
+        {
+            // arrange
+            const int batchSize = 3;
+
+            var container = new WindsorContainer();
+            container.Register(Component.For<IWindsorContainer>().Instance(container));
+            container.Register(Component.For<IApplicationCache>().ImplementedBy<InMemoryApplicationCache>());
+            container.Register(Component.For<ILazyComponentLoader>().ImplementedBy<AutoMockingLazyComponentLoader>());
+
+            var connectionMock = new Mock<IConnectorConnectionV2>();
+            connectionMock.Setup(x => x.Authentication).Returns(new Dictionary<string, object>
+            {
+                { AzureEventHubConstants.KeyName.ConnectionString, TestEventHubConnectionString },
+                { AzureEventHubConstants.KeyName.Name, TestEventHubName },
+                { AzureEventHubConstants.KeyName.CombineMessages, true },
+                { AzureEventHubConstants.KeyName.BatchSize, batchSize },
+            });
+
+            var clockMock = new Mock<IClockService>();
+            clockMock.Setup(x => x.Now)
+                .Returns(new DateTimeOffset(new DateTime(2023, 5, 15, 9, 17, 0, DateTimeKind.Utc), TimeSpan.Zero)
+                    .ToUniversalTime());
+            container.Register(Component.For<IClockService>().Instance(clockMock.Object));
+
+            var executionContext = container.Resolve<ExecutionContext>();
+
+            var connectorMock = new Mock<AzureEventHubConnector>(MockBehavior.Default,
+                typeof(AzureEventHubConnector).GetConstructors().First().GetParameters()
+                    .Select(p => container.Resolve(p.ParameterType)).ToArray());
+
+            var providerDefinitionId = Guid.NewGuid();
+
+            connectorMock.CallBase = true;
+            connectorMock.Setup(x => x.GetAuthenticationDetails(executionContext, providerDefinitionId))
+                .ReturnsAsync(connectionMock.Object);
+
+            // batchSize distinct entities, so a single Chunk group - and therefore a single combined message -
+            // covers all of them, making the assertions below deterministic.
+            var entityIds = Enumerable.Range(0, batchSize).Select(_ => Guid.NewGuid().ToString()).ToArray();
+
+            var entities = entityIds.Select(entityId => new ConnectorEntityData(VersionChangeType.Changed, StreamMode.Sync,
+                Guid.Parse(entityId),
+                new ConnectorEntityPersistInfo("1lzghdhhgqlnucj078/77q==", 1), null,
+                EntityCode.FromKey($"/Person#Acceptance:{entityId}"),
+                "/Person",
+                new[]
+                {
+                    new ConnectorPropertyData("user.lastName", "Picard",
+                        new VocabularyKeyConnectorPropertyDataType(new VocabularyKey("user.lastName"))),
+                    new ConnectorPropertyData("Name", "Jean Luc Picard",
+                        new EntityPropertyConnectorPropertyDataType(typeof(string))),
+                },
+                new IEntityCode[] { EntityCode.FromKey($"/Person#Acceptance:{entityId}") },
+                null, null)).ToArray();
+
+            var streamModel = new Mock<IReadOnlyStreamModel>();
+            streamModel.Setup(x => x.ConnectorProviderDefinitionId).Returns(providerDefinitionId);
+            streamModel.Setup(x => x.ContainerName).Returns("test_container");
+            streamModel.Setup(x => x.Mode).Returns(StreamMode.Sync);
+
+            var connector = connectorMock.Object;
+
+            var client = new EventHubConsumerClient("$Default", RootConnectionString, TestEventHubName);
+
+            var hubEmptyEvent = new AutoResetEvent(false);
+            var messageReceivedEvent = new AutoResetEvent(false);
+            EventData eventData = null;
+
+            var _ = Task.Run(async () =>
+            {
+                var options = new ReadEventOptions
+                {
+                    MaximumWaitTime = TimeSpan.FromSeconds(1),
+                };
+
+                while (true)
+                {
+                    await foreach (var partitionEvent in client.ReadEventsAsync(options))
+                    {
+                        if (partitionEvent.Data == null)
+                        {
+                            hubEmptyEvent.Set();
+                        }
+                        else
+                        {
+                            var s = Encoding.UTF8.GetString(partitionEvent.Data.Body.ToArray());
+
+                            // only a genuinely combined message will contain every one of our fresh guids at once
+                            if (entityIds.All(id => s.Contains(id)))
+                            {
+                                eventData = partitionEvent.Data;
+                                messageReceivedEvent.Set();
+                                return;
+                            }
+                        }
+                    }
+                }
+            });
+
+            if (!hubEmptyEvent.WaitOne(60000))
+            {
+                throw new TimeoutException();
+            }
+
+            // act - fire every StoreData call concurrently (not awaited individually) so all items are
+            // added to the buffer before the idle flush timer fires, landing them in the same flush/chunk
+            var storeTasks = entities
+                .Select(data => connector.StoreData(executionContext, streamModel.Object, data))
+                .ToArray();
+
+            await Task.WhenAll(storeTasks);
+
+            // assert
+            if (!messageReceivedEvent.WaitOne(60000))
+            {
+                throw new TimeoutException();
+            }
+
+            var receivedBody = Encoding.UTF8.GetString(eventData.Body.ToArray());
+            var parsed = JObject.Parse(receivedBody);
+
+            ((int)parsed["count"]).Should().Be(batchSize);
+
+            var messages = (JArray)parsed["messages"];
+            messages.Should().HaveCount(batchSize);
+
+            var receivedIds = messages.Select(m => (string)m["Id"]).ToArray();
+            receivedIds.Should().BeEquivalentTo(entityIds);
         }
     }
 }

--- a/test/unit/Connector.SqlServer.Test/Connector/AzureEventHubConnectorMessageCombiningTests.cs
+++ b/test/unit/Connector.SqlServer.Test/Connector/AzureEventHubConnectorMessageCombiningTests.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Linq;
+using System.Text;
+using Azure.Messaging.EventHubs;
+using CluedIn.Connector.AzureEventHub;
+using CluedIn.Connector.AzureEventHub.Connector;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace CluedIn.Connector.AzureEventHub.Unit.Tests.Connector
+{
+    // Covers AzureEventHubConnector.Chunk and .CombineEventData - the two helpers behind the opt-in
+    // message-combining feature (AzureEventHubConstants.KeyName.CombineMessages / BatchSize). Both are
+    // internal static and exposed to this assembly via [InternalsVisibleTo] in src/Connector.SqlServer/AssemblyInfo.cs.
+    public class AzureEventHubConnectorMessageCombiningTests
+    {
+        private static EventData CreateEventData(string body) => new EventData(Encoding.UTF8.GetBytes(body));
+
+        private static string GetBody(EventData eventData) => Encoding.UTF8.GetString(eventData.Body.ToArray());
+
+        public class ChunkTests
+        {
+            [Fact]
+            public void EmptyInput_YieldsNoChunks()
+            {
+                var chunks = AzureEventHubConnector.Chunk(Array.Empty<EventData>(), 10).ToArray();
+
+                Assert.Empty(chunks);
+            }
+
+            [Fact]
+            public void FewerItemsThanBatchSize_YieldsSingleChunkWithAllItems()
+            {
+                var items = new[] { CreateEventData("{}"), CreateEventData("{}") };
+
+                var chunks = AzureEventHubConnector.Chunk(items, 10).ToArray();
+
+                Assert.Single(chunks);
+                Assert.Equal(2, chunks[0].Length);
+            }
+
+            [Fact]
+            public void SplitsIntoGroupsOfAtMostBatchSize()
+            {
+                var items = Enumerable.Range(0, 7).Select(i => CreateEventData($"{{\"i\":{i}}}")).ToArray();
+
+                var chunks = AzureEventHubConnector.Chunk(items, 3).ToArray();
+
+                Assert.Equal(3, chunks.Length);
+                Assert.Equal(3, chunks[0].Length);
+                Assert.Equal(3, chunks[1].Length);
+                Assert.Single(chunks[2]);
+            }
+
+            [Fact]
+            public void BatchSizeOne_PutsEachItemInItsOwnChunk()
+            {
+                var items = Enumerable.Range(0, 3).Select(i => CreateEventData($"{{\"i\":{i}}}")).ToArray();
+
+                var chunks = AzureEventHubConnector.Chunk(items, 1).ToArray();
+
+                Assert.Equal(3, chunks.Length);
+                Assert.All(chunks, chunk => Assert.Single(chunk));
+            }
+
+            [Fact]
+            public void PreservesItemOrderAcrossAndWithinChunks()
+            {
+                var items = Enumerable.Range(0, 5).Select(i => CreateEventData($"{{\"i\":{i}}}")).ToArray();
+
+                var chunks = AzureEventHubConnector.Chunk(items, 2).ToArray();
+
+                var flattenedBodies = chunks.SelectMany(chunk => chunk).Select(GetBody).ToArray();
+                var originalBodies = items.Select(GetBody).ToArray();
+                Assert.Equal(originalBodies, flattenedBodies);
+            }
+
+            [Fact]
+            public void SplitsEarlyWhenCombinedByteSizeWouldExceedMax()
+            {
+                // Two items exactly filling MaxCombinedMessageBytes between them stay in one chunk (boundary is
+                // strictly-greater-than); a third item then forces a split before it's added, even though the
+                // batchSize limit (10) was never reached by count.
+                var halfMax = AzureEventHubConstants.MaxCombinedMessageBytes / 2;
+                var item1 = CreateEventData(new string('a', halfMax));
+                var item2 = CreateEventData(new string('b', halfMax));
+                var item3 = CreateEventData(new string('c', halfMax));
+
+                var chunks = AzureEventHubConnector.Chunk(new[] { item1, item2, item3 }, 10).ToArray();
+
+                Assert.Equal(2, chunks.Length);
+                Assert.Equal(2, chunks[0].Length);
+                Assert.Single(chunks[1]);
+            }
+
+            [Fact]
+            public void SingleItemLargerThanMaxIsKeptAloneRatherThanDroppedOrSplit()
+            {
+                var oversized = CreateEventData(new string('x', AzureEventHubConstants.MaxCombinedMessageBytes + 1000));
+                var normal = CreateEventData("{}");
+
+                var chunks = AzureEventHubConnector.Chunk(new[] { oversized, normal }, 10).ToArray();
+
+                Assert.Equal(2, chunks.Length);
+                Assert.Single(chunks[0]);
+                Assert.Single(chunks[1]);
+                Assert.Equal(GetBody(oversized), GetBody(chunks[0][0]));
+            }
+        }
+
+        public class CombineEventDataTests
+        {
+            [Fact]
+            public void WrapsBodiesInCountAndMessagesEnvelope()
+            {
+                var items = new[] { CreateEventData("{\"a\":1}"), CreateEventData("{\"b\":2}") };
+
+                var combined = AzureEventHubConnector.CombineEventData(items);
+
+                Assert.Equal("{\"count\":2,\"messages\":[{\"a\":1},{\"b\":2}]}", GetBody(combined));
+            }
+
+            [Fact]
+            public void SingleItem_WrapsWithoutTrailingComma()
+            {
+                var items = new[] { CreateEventData("{\"a\":1}") };
+
+                var combined = AzureEventHubConnector.CombineEventData(items);
+
+                Assert.Equal("{\"count\":1,\"messages\":[{\"a\":1}]}", GetBody(combined));
+            }
+
+            [Fact]
+            public void ConcatenatesRawBodiesVerbatimWithoutReparsing()
+            {
+                // Whitespace/formatting inside each body must survive untouched - proves the bodies are
+                // string-concatenated as-is rather than deserialized and re-serialized.
+                var items = new[] { CreateEventData("{\n  \"a\": 1\n}"), CreateEventData("{\"b\":2}") };
+
+                var combined = AzureEventHubConnector.CombineEventData(items);
+
+                Assert.Equal("{\"count\":2,\"messages\":[{\n  \"a\": 1\n},{\"b\":2}]}", GetBody(combined));
+            }
+
+            [Fact]
+            public void ResultIsWellFormedJsonWithMatchingCountAndMessageArrayLength()
+            {
+                var items = new[]
+                {
+                    CreateEventData("{\"a\":1}"),
+                    CreateEventData("{\"b\":2}"),
+                    CreateEventData("{\"c\":3}"),
+                };
+
+                var combined = AzureEventHubConnector.CombineEventData(items);
+
+                var parsed = JObject.Parse(GetBody(combined));
+                Assert.Equal(3, (int)parsed["count"]);
+                Assert.Equal(3, ((JArray)parsed["messages"]).Count);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds an opt-in `combineMessages` setting (with configurable `batchSize`) so customers billed per message by their downstream consumer can pack multiple records into a single Event Hub message body instead of one message per record.
- The buffer's own flush size/cadence (50 items / 10s) stays fixed regardless of this setting, since it's coupled to the platform's RabbitMQ prefetch-driven backpressure - `batchSize` only subdivides *within* an already-completed flush (clamped to at most the flush size), so it can never stall message delivery.
- When combining is off, behavior is unchanged from today - one Event Hub message per record.
- Updates `docs/4.5.2-release-notes.md`.

## Test plan
- [x] `dotnet build` on `Connector.AzureEventHub.csproj` - 0 errors (2 pre-existing, unrelated obsolete-API warnings)
- [x] `dotnet build` + `dotnet test` on the unit test project - 0 errors, 4/4 passing
- [ ] Integration tests against a live Event Hub - not runnable from the dev sandbox (outbound AMQPS/5671 blocked there); needs to run from an environment with that egress before merging
- [ ] Manual verification of the combined message payload shape against the customer's actual downstream consumer expectations