### PR TITLE
fix: dispose the evicted producer client on send failure

### DIFF
--- a/src/Connector.SqlServer/Connector/AzureEventHubConnector.cs
+++ b/src/Connector.SqlServer/Connector/AzureEventHubConnector.cs
@@ -102,6 +102,19 @@ namespace CluedIn.Connector.AzureEventHub.Connector
             catch
             {
                 _cache.Remove(clientKey);
+
+                // The client that just failed is evicted so a fresh one is created next time - but leaving it
+                // open here would leak its underlying AMQP connection, since nothing else ever closes it. Best
+                // effort: a failure to close must not shadow the original send failure being rethrown below.
+                try
+                {
+                    await client.CloseAsync();
+                }
+                catch
+                {
+                    // ignored - the send failure below is the one that matters
+                }
+
                 throw;
             }
         }


### PR DESCRIPTION
## Summary
Addresses a review comment from PR #38 on `src/Connector.SqlServer/Connector/AzureEventHubConnector.cs`:

> On SendAsync failure the cache entry is removed but the EventHubProducerClient is never disposed/closed, which can leak AMQP connections. Dispose the removed client (and consider doing the same on connector shutdown).

- Closes the evicted client in `Flush`'s catch block.
- Closing is wrapped in its own try/catch so a failure to close can't shadow the original send exception that's being rethrown.
- Scoped to the concrete, actionable part of the comment (the leak on eviction). Didn't extend this to connector-shutdown-wide disposal, since `AzureEventHubConnector` doesn't implement `IDisposable`/`IAsyncDisposable` today - that would be a larger change than this comment strictly requires; happy to follow up separately if wanted.

## Test plan
- [x] `dotnet build` - 0 errors (2 pre-existing, unrelated obsolete-API warnings)