### PR TITLE
fix: enforce BatchSize's documented 1-50 range in its validation regex

### DIFF
--- a/src/Connector.SqlServer/AzureEventHubConstants.cs
+++ b/src/Connector.SqlServer/AzureEventHubConstants.cs
@@ -98,11 +98,13 @@ namespace CluedIn.Connector.AzureEventHub
                 Help = $"Records per combined message, 1-{DefaultFlushSize} (default {DefaultBatchSize}). Only applies when combining messages is enabled.",
                 Type = "input",
                 IsRequired = false,
+                // "[1-4][0-9]" only covers 10-49 - hand-built for DefaultFlushSize=50 specifically, not derived
+                // from it. If DefaultFlushSize ever changes, this pattern needs updating to match.
                 ValidationRules = new List<Dictionary<string, string>>()
                 {
                     new() {
-                        { "regex", "^[1-9][0-9]*$" },
-                        { "message", "Must be a whole number greater than zero" }
+                        { "regex", $"^([1-9]|[1-4][0-9]|{DefaultFlushSize})$" },
+                        { "message", $"Must be a whole number from 1 to {DefaultFlushSize}" }
                     }
                 },
             },


### PR DESCRIPTION
## Summary
Addresses a review comment from PR #38 on `src/Connector.SqlServer/AzureEventHubConstants.cs`:

> Batch size help text says "1-50" but the validation rule only enforces a positive integer (no upper bound). Either enforce the documented max in validation or adjust the help text to match actual validation behavior.

- Tightened the regex from `^[1-9][0-9]*$` to `^([1-9]|[1-4][0-9]|50)$` (interpolated from `DefaultFlushSize`), so it now actually enforces the documented 1-50 range client-side instead of accepting any positive integer.
- Left a comment flagging that the `[1-4][0-9]` alternative is hand-built for 50 specifically (not algorithmically derived from `DefaultFlushSize`), so it needs a matching update if that constant ever changes.

## Test plan
- [x] `dotnet build` - 0 errors (2 pre-existing, unrelated obsolete-API warnings)