### PR TITLE
docs: correct a stale comment about the test-project LangVersion default

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -3,9 +3,10 @@
 
   <PropertyGroup>
     <IsTestProject>true</IsTestProject>
-    <!-- Raised from the repo-wide default (C# 10, implied by net6.0) so test assertions can use raw string
-         literals ("""..."""). Compile-time only - doesn't affect the net6.0 target or runtime behavior, and is
-         scoped to test projects only via this file rather than the shipped connector assembly under src/. -->
+    <!-- Explicitly set to 11 so test assertions can use raw string literals ("""..."""). Without this, the
+         C# language version is whatever the SDK pinned in ../global.json defaults to for a net6.0 target, which
+         predates raw string literals. Compile-time only - doesn't affect the net6.0 target or runtime behavior,
+         and is scoped to test projects only via this file rather than the shipped connector assembly under src/. -->
     <LangVersion>11</LangVersion>
     <!-- CI's UseDotNet@2 step installs only the single SDK/runtime pinned in ../global.json (now 8.0.100, bumped
          for the LangVersion 11 requirement above), not the net6.0 runtime these test projects target - without


### PR DESCRIPTION
## Summary
Addresses a review comment from PR #38 on `test/Directory.Build.props`:

> This comment claims the repo-wide default is "C# 10, implied by net6.0", but language version defaults are determined by the SDK (and global.json is now .NET 8). Update the comment so it stays accurate.

- Reworded to describe the actual dependency (the SDK version pinned in `global.json`) instead of the incorrect net6.0-implies-C#10 claim.

## Test plan
- [x] `dotnet build` on the unit test project - 0 errors (docs-only change)