### PR TITLE
fix: dispose EventHubConsumerClient and AutoResetEvents in integration tests

### DIFF
--- a/test/integration/Connector.AzureEventHub.Integration.Tests/AzureEventHubConnectorTests.cs
+++ b/test/integration/Connector.AzureEventHub.Integration.Tests/AzureEventHubConnectorTests.cs
@@ -128,10 +128,10 @@ namespace CluedIn.Connector.AzureEventHub.Integration.Tests
 
             var connector = connectorMock.Object;
 
-            var client = new EventHubConsumerClient("$Default", RootConnectionString, TestEventHubName);
+            await using var client = new EventHubConsumerClient("$Default", RootConnectionString, TestEventHubName);
 
-            var hubEmptyEvent = new AutoResetEvent(false);
-            var messageReceivedEvent = new AutoResetEvent(false);
+            using var hubEmptyEvent = new AutoResetEvent(false);
+            using var messageReceivedEvent = new AutoResetEvent(false);
             EventData eventData = null;
 
             var _ = Task.Run(async () =>
@@ -281,10 +281,10 @@ namespace CluedIn.Connector.AzureEventHub.Integration.Tests
 
             var connector = connectorMock.Object;
 
-            var client = new EventHubConsumerClient("$Default", RootConnectionString, TestEventHubName);
+            await using var client = new EventHubConsumerClient("$Default", RootConnectionString, TestEventHubName);
 
-            var hubEmptyEvent = new AutoResetEvent(false);
-            var messageReceivedEvent = new AutoResetEvent(false);
+            using var hubEmptyEvent = new AutoResetEvent(false);
+            using var messageReceivedEvent = new AutoResetEvent(false);
             EventData eventData = null;
 
             var _ = Task.Run(async () =>


### PR DESCRIPTION
## Summary
Addresses a review comment from PR #38 on `test/integration/Connector.AzureEventHub.Integration.Tests/AzureEventHubConnectorTests.cs`:

> The new integration test creates EventHubConsumerClient and AutoResetEvents without disposing them. If the test times out/fails, these can leak resources and keep background work running. Use (await) using to ensure cleanup.

- Switched `EventHubConsumerClient` to `await using` and both `AutoResetEvent`s to `using` declarations, so cleanup runs on any exit path (success, assertion failure, or timeout).
- The flagged comment was scoped to the new combining test, but the identical pattern already existed in the pre-existing `VerifyCanStoreData` test in the same file - fixed both together rather than leaving one intentionally inconsistent.

## Test plan
- [x] `dotnet build` on the integration test project - 0 errors, 0 warnings