### PR TITLE
fix: correct the JSON shape shown in CombineMessages' help text

### DIFF
--- a/src/Connector.SqlServer/AzureEventHubConstants.cs
+++ b/src/Connector.SqlServer/AzureEventHubConstants.cs
@@ -87,7 +87,7 @@ namespace CluedIn.Connector.AzureEventHub
             {
                 Name = KeyName.CombineMessages,
                 DisplayName = "Combine multiple records into a single Event Hub message",
-                Help = "When enabled, records are combined into a single message wrapped as {\"count\", \"messages\"} instead of being sent individually - make sure your downstream consumer can parse this format.",
+                Help = "When enabled, records are combined into a single message wrapped as {\"count\": N, \"messages\": [...]} instead of being sent individually - make sure your downstream consumer can parse this format.",
                 Type = "checkbox",
                 IsRequired = false,
             },


### PR DESCRIPTION
## Summary
Addresses a review comment from PR #38 on `src/Connector.SqlServer/AzureEventHubConstants.cs`:

> The help text shows an invalid/ambiguous JSON shape ("{\"count\", \"messages\"}") even though the actual payload is {"count":N,"messages":[...]}. Updating this text reduces the chance of downstream consumer confusion.

- Fixed the `Help` text on the `CombineMessages` control to show the real shape, `{"count": N, "messages": [...]}`, matching what `AzureEventHubConnector.CombineEventData` actually produces.

## Test plan
- [x] `dotnet build` - 0 errors (2 pre-existing, unrelated obsolete-API warnings)